### PR TITLE
feat(ui): improve sidebar logo readability

### DIFF
--- a/Toolchain/Templates/index.html
+++ b/Toolchain/Templates/index.html
@@ -24,7 +24,7 @@
             <div class="col-md-3 sidebar">
                 <div class="sidebar-content">
                     <div class="logo-section text-center mb-3">
-                        <img src="{{ url_for('static', filename='assets/logo_markleaf.svg') }}" alt="MarkLeaf" style="max-width: 220px; height: auto;">
+                        <img class="logo-img" src="{{ url_for('static', filename='assets/logo_markleaf.svg') }}" alt="MarkLeaf">
                     </div>
                     <div class="gradient-divider mb-4" aria-hidden="true"></div>
                     

--- a/Toolchain/static/css/style.css
+++ b/Toolchain/static/css/style.css
@@ -104,6 +104,7 @@ body {
     bottom: 0;
     background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grain" width="100" height="100" patternUnits="userSpaceOnUse"><circle cx="25" cy="25" r="1" fill="rgba(255,255,255,0.03)"/><circle cx="75" cy="75" r="1" fill="rgba(255,255,255,0.03)"/><circle cx="50" cy="10" r="0.5" fill="rgba(255,255,255,0.02)"/><circle cx="10" cy="60" r="0.5" fill="rgba(255,255,255,0.02)"/><circle cx="90" cy="40" r="0.5" fill="rgba(255,255,255,0.02)"/></pattern></defs><rect width="100" height="100" fill="url(%23grain)"/></svg>');
     pointer-events: none;
+    opacity: 0.12; /* lighten grain so logo remains legible */
 }
 
 .sidebar-content {
@@ -124,6 +125,31 @@ body {
     font-size: 3rem;
     color: #fbbf24;
     margin-bottom: 0.5rem;
+}
+
+/* Sidebar logo readability improvements */
+.sidebar .logo-section {
+    padding: 1rem 1rem 0.75rem;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 12px;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+    backdrop-filter: saturate(120%) blur(2px);
+    -webkit-backdrop-filter: saturate(120%) blur(2px);
+}
+
+.sidebar .logo-section .logo-img {
+    display: block;
+    margin: 0 auto;
+    width: min(100%, 240px);
+    height: auto;
+    image-rendering: -webkit-optimize-contrast;
+    filter: drop-shadow(0 1px 0 rgba(255, 255, 255, 0.35)) drop-shadow(0 4px 12px rgba(0, 0, 0, 0.25));
+}
+
+[data-theme="dark"] .sidebar .logo-section {
+    background: rgba(0, 0, 0, 0.22);
+    border-color: rgba(255, 255, 255, 0.12);
 }
 
 .features-list {


### PR DESCRIPTION
Add dedicated logo class; remove inline style
Add contrast panel, border, soft shadow, responsive sizing Reduce background grain behind logo
Tweak dark-mode styling for balanced contrast

<!-- Use a Conventional Commit title, e.g., feat(toolchain): add PDF renderer -->

Summary
Migliora la leggibilità del logo nella sidebar con uno sfondo leggero, ombre morbide e dimensionamento responsivo.
Esito per utenti/maintainer: migliore contrasto in light/dark mode, stile centralizzato in CSS (niente inline), manutenzione più semplice.
Changes
Aggiunta classe dedicata .logo-img e rimozione stile inline.
Pannello semi-trasparente dietro al logo con bordo, raggio e soft shadow.
Ridotta l’opacità della grana di sfondo dietro al logo.
Dimensionamento responsivo fino a 240px, rendering ottimizzato e drop-shadow combinato.
Tuning dark-mode per mantenere contrasto bilanciato.
File toccati

Toolchain/Templates/index.html
Toolchain/static/css/style.css
Testing
Avvio locale (Flask):
export FLASK_APP=Toolchain/app.py
flask run
Apri http://localhost:5000/
Verifiche:
Light mode: logo ben leggibile sul gradiente, nessuna clip a 240px.
Dark mode: pannello e bordo visibili, ombra equilibrata.
Mobile (<768px): logo centrato e ridimensionato correttamente; la features list sparisce come da media query.
Accessibilità: alt="MarkLeaf" presente; nessuna regressione di navigazione da tastiera.
Edge cases:
Loghi molto chiari/scuri: leggibili grazie al pannello e drop-shadow, ma potrebbero richiedere tarature future per brand molto estremi.
Screenshots/Logs (optional)
<!-- Aggiungi immagini prima/dopo se disponibili. -->


Checklist
 PR title follows Conventional Commits (type(scope): subject)
 Linked issue referenced (e.g., Closes #123)
 CI is green ("CI / build (ubuntu-latest)")
 No secrets or sensitive data committed (.env, keys, tokens)
 Docs updated if needed (README, docs/)
 Small, focused diff; rationale clear
Risk & Rollout
Risk level: Low
Rollback plan: Revert PR per ripristinare la precedente UI della sidebar

