### PR TITLE
fix(eisvogel+ui): restore stable PDF preview and update sidebar logo

### DIFF
--- a/Toolchain/Templates/classic/default.tex
+++ b/Toolchain/Templates/classic/default.tex
@@ -70,8 +70,7 @@ $endif$
 \newcolumntype{P}[1]{>{\RaggedRight\arraybackslash}p{#1}}
 
 % Code block styling (Shaded environment)
-\definecolor{shadecolor}{RGB}{248,248,248}
-\newenvironment{Shaded}{\begin{snugshade}}{\end{snugshade}}
+% Using Pandoc-provided highlighting macros; avoid local Shaded redefinition
 
 % Pandoc highlighting macros (define Highlighting environment, etc.)
 $if(highlighting-macros)$

--- a/Toolchain/Templates/consulting/default.tex
+++ b/Toolchain/Templates/consulting/default.tex
@@ -80,8 +80,7 @@ $endif$
 \newcolumntype{P}[1]{>{\RaggedRight\arraybackslash}p{#1}}
 
 % Code block styling (Shaded environment)
-\definecolor{shadecolor}{RGB}{248,248,248}
-\newenvironment{Shaded}{\begin{snugshade}}{\end{snugshade}}
+% Using Pandoc-provided highlighting macros; avoid local Shaded redefinition
 
 % Pandoc highlighting macros (define Highlighting environment, etc.)
 $if(highlighting-macros)$

--- a/Toolchain/Templates/index.html
+++ b/Toolchain/Templates/index.html
@@ -23,8 +23,8 @@
             <!-- Sidebar -->
             <div class="col-md-3 sidebar">
                 <div class="sidebar-content">
-                    <div class="logo-section text-center mb-3">
-                        <img class="logo-img" src="{{ url_for('static', filename='assets/logo_markleaf.svg') }}" alt="MarkLeaf">
+                    <div class="logo-section logo-right mb-3">
+                        <img class="logo-img" src="{{ url_for('static', filename='assets/BLD_LOGO_Primary_Horizontal_RGB.pdf') }}" alt="MarkLeaf">
                     </div>
                     <div class="gradient-divider mb-4" aria-hidden="true"></div>
                     


### PR DESCRIPTION
Summary
Ripristina uno stato stabile: niente errori LaTeX “Shaded” e logo della sidebar funzionante (niente 404).
Focus: preview/generation affidabili con Classic/Consulting e Eisvogel; logo PDF OK.
Changes
Toolchain/Templates/classic/default.tex: rimosso newenvironment{Shaded}; usate le macro di Pandoc per Highlighting
Toolchain/Templates/consulting/default.tex: rimosso newenvironment{Shaded}; usate le macro di Pandoc per Highlighting
Toolchain/publish.sh: per Eisvogel usa --listings (no Shaded); mantiene supporto logo PDF
Toolchain/Templates/index.html: logo sidebar puntato a asset esistente (BLD_LOGO_Primary_Horizontal_RGB.pdf)
Testing
Avvio: export FLASK_APP=Toolchain/app.py && flask run
Classic/Consulting: carica un .md semplice → Preview/Generate OK (no “Shaded”/“Highlighting undefined”)
Eisvogel: Title page ON; carica logo PDF → Preview/Generate OK
Sidebar: il logo compare (niente 404)
Checklist
 PR title follows Conventional Commits
 No secrets committed
 Small, focused diff; rationale chiara
 CI green
Risk & Rollout
Risk: Low
Rollback: revert PR